### PR TITLE
Fix Undefined issue on location selection

### DIFF
--- a/static/views/landing.html
+++ b/static/views/landing.html
@@ -584,7 +584,7 @@ body{background:#f7f7f7;}
 				  document.getElementById('search-location-suggestions').innerHTML = suggestions;
 				  for (var item of res) {
 					document.getElementById('loc-option-'+item.name).addEventListener('click', function(e) {
-						document.getElementById('search-location').value = e.target.outerText;
+						document.getElementById('search-location').value = e.target.textContent;
 						document.getElementById('search-location-suggestions').style.display = 'none';
 					});
 				  }


### PR DESCRIPTION
When the location filter is selected from the location suggestion on the landing page it shows undefined on firefox, this PR fixes that. You guys were using `outerText` to get the value from div which is not supported on firefox, look into this reference for details

https://developer.mozilla.org/en-US/docs/Web/API/HTMLElement/outerText

