### PR TITLE
Fix Undefined issue on search tag selection 

### DIFF
--- a/static/views/landing.html
+++ b/static/views/landing.html
@@ -620,7 +620,7 @@ body{background:#f7f7f7;}
 				  document.getElementById('search-tag-suggestions').innerHTML = suggestions;
 				  for (var item of res) {
 					document.getElementById('tag-option-'+item.name).addEventListener('click', function(e) {
-						document.getElementById('search-tag').value = e.target.outerText;
+						document.getElementById('search-tag').value = e.target.textContent;
 						document.getElementById('search-tag-suggestions').style.display = 'none';
 					});
 				  }


### PR DESCRIPTION
When the search tag is selected from the suggestion on the landing page it shows undefined on firefox, this PR fixes that.