### PR TITLE
Add developer profile CV uploads

### DIFF
--- a/internal/developer/model.go
+++ b/internal/developer/model.go
@@ -84,6 +84,8 @@ type Developer struct {
 	RoleLevel          string
 	RoleTypes          []string
 	DetectedLocationID *string
+	CV                 []byte
+	HasCV              bool
 
 	Bio                string
 	SkillsArray        []string

--- a/internal/developer/repository.go
+++ b/internal/developer/repository.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/gosimple/slug"
+	"github.com/segmentio/ksuid"
 )
 
 const (
@@ -24,7 +25,7 @@ func NewRepository(db *sql.DB) *Repository {
 }
 
 func (r *Repository) DeveloperProfileBySlug(slug string) (Developer, error) {
-	row := r.db.QueryRow(`SELECT id, email, location, available, linkedin_url, hourly_rate, image_id, slug, created_at, updated_at, skills, name, bio, github_url, twitter_url, search_status, role_level, role_types FROM developer_profile WHERE slug = $1`, slug)
+	row := r.db.QueryRow(`SELECT id, email, location, available, linkedin_url, hourly_rate, image_id, slug, created_at, updated_at, skills, name, bio, github_url, twitter_url, search_status, role_level, role_types, cv IS NOT NULL FROM developer_profile WHERE slug = $1`, slug)
 	dev := Developer{}
 	var roleTypes string
 	err := row.Scan(
@@ -46,6 +47,7 @@ func (r *Repository) DeveloperProfileBySlug(slug string) (Developer, error) {
 		&dev.SearchStatus,
 		&dev.RoleLevel,
 		&roleTypes,
+		&dev.HasCV,
 	)
 	dev.RoleTypes = strings.Split(roleTypes, ",")
 	if err != nil {
@@ -56,7 +58,7 @@ func (r *Repository) DeveloperProfileBySlug(slug string) (Developer, error) {
 }
 
 func (r *Repository) DeveloperProfileByEmail(email string) (Developer, error) {
-	row := r.db.QueryRow(`SELECT id, email, location, available, linkedin_url, hourly_rate, image_id, slug, created_at, updated_at, skills, name, bio FROM developer_profile WHERE lower(email) = lower($1)`, email)
+	row := r.db.QueryRow(`SELECT id, email, location, available, linkedin_url, hourly_rate, image_id, slug, created_at, updated_at, skills, name, bio, cv IS NOT NULL FROM developer_profile WHERE lower(email) = lower($1)`, email)
 	dev := Developer{}
 	var nullUpdatedAt sql.NullTime
 	err := row.Scan(
@@ -73,6 +75,7 @@ func (r *Repository) DeveloperProfileByEmail(email string) (Developer, error) {
 		&dev.Skills,
 		&dev.Name,
 		&dev.Bio,
+		&dev.HasCV,
 	)
 	if nullUpdatedAt.Valid {
 		dev.UpdatedAt = nullUpdatedAt.Time
@@ -112,7 +115,7 @@ func (r *Repository) DeveloperMetadataByProfileID(metadata_type string, profile_
 }
 
 func (r *Repository) DeveloperProfileByID(id string) (Developer, error) {
-	row := r.db.QueryRow(`SELECT id, email, location, linkedin_url, hourly_rate, image_id, slug, created_at, updated_at, skills, name, bio, search_status, role_level FROM developer_profile WHERE id = $1`, id)
+	row := r.db.QueryRow(`SELECT id, email, location, linkedin_url, hourly_rate, image_id, slug, created_at, updated_at, skills, name, bio, search_status, role_level, cv IS NOT NULL FROM developer_profile WHERE id = $1`, id)
 	dev := Developer{}
 	var nullTime sql.NullTime
 	err := row.Scan(
@@ -130,6 +133,7 @@ func (r *Repository) DeveloperProfileByID(id string) (Developer, error) {
 		&dev.Bio,
 		&dev.SearchStatus,
 		&dev.RoleLevel,
+		&dev.HasCV,
 	)
 	if nullTime.Valid {
 		dev.UpdatedAt = nullTime.Time
@@ -380,6 +384,12 @@ func (r *Repository) DevelopersByLocationAndTag(loc, tag string, pageID, pageSiz
 
 func (r *Repository) UpdateDeveloperProfile(dev Developer) error {
 	_, err := r.db.Exec(`UPDATE developer_profile SET name = $1, location = $2, linkedin_url = $3, hourly_rate = $4, bio = $5, available = $6, image_id = $7, updated_at = NOW(), skills = $8, search_status = $9, role_level = $10  WHERE id = $11`, dev.Name, dev.Location, dev.LinkedinURL, dev.HourlyRate, dev.Bio, dev.Available, dev.ImageID, dev.Skills, dev.SearchStatus, dev.RoleLevel, dev.ID)
+	if err != nil {
+		return err
+	}
+	if len(dev.CV) > 0 {
+		_, err = r.db.Exec(`UPDATE developer_profile SET cv = $1, updated_at = NOW() WHERE id = $2`, dev.CV, dev.ID)
+	}
 	return err
 }
 
@@ -395,8 +405,12 @@ func (r *Repository) ActivateDeveloperProfile(email string) error {
 
 func (r *Repository) SaveDeveloperProfile(dev Developer) error {
 	dev.Slug = slug.Make(fmt.Sprintf("%s %d", dev.Name, time.Now().UTC().Unix()))
+	var cv interface{}
+	if len(dev.CV) > 0 {
+		cv = dev.CV
+	}
 	_, err := r.db.Exec(
-		`INSERT INTO developer_profile (email, location, linkedin_url, hourly_rate, bio, available, image_id, slug, created_at, updated_at, skills, name, id, github_url, twitter_url, role_types, role_level, search_status, detected_location_id) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW(), $9, $10, $11, $12, $13, $14, $15, $16, $17)`,
+		`INSERT INTO developer_profile (email, location, linkedin_url, hourly_rate, bio, available, image_id, slug, created_at, updated_at, skills, name, id, github_url, twitter_url, role_types, role_level, search_status, detected_location_id, cv) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW(), $9, $10, $11, $12, $13, $14, $15, $16, $17, $18)`,
 		dev.Email,
 		dev.Location,
 		dev.LinkedinURL,
@@ -414,8 +428,19 @@ func (r *Repository) SaveDeveloperProfile(dev Developer) error {
 		dev.RoleLevel,
 		dev.SearchStatus,
 		dev.DetectedLocationID,
+		cv,
 	)
 	return err
+}
+
+func (r *Repository) DeveloperProfileCVByID(id string) (Developer, error) {
+	row := r.db.QueryRow(`SELECT id, name, cv FROM developer_profile WHERE id = $1 AND cv IS NOT NULL`, id)
+	dev := Developer{}
+	err := row.Scan(&dev.ID, &dev.Name, &dev.CV)
+	if err != nil {
+		return dev, err
+	}
+	return dev, nil
 }
 
 func (r *Repository) SaveDeveloperMetadata(devMetadata DeveloperMetadata) error {
@@ -560,6 +585,16 @@ func (r *Repository) TrackDeveloperProfileView(dev Developer) error {
 func (r *Repository) TrackDeveloperProfileMessageSent(dev Developer) error {
 	stmt := `INSERT INTO developer_profile_event (event_type, developer_profile_id, created_at) VALUES ($1, $2, NOW())`
 	_, err := r.db.Exec(stmt, developerProfileEventMessageSent, dev.ID)
+	return err
+}
+
+func (r *Repository) TrackDeveloperProfileCVDownload(dev Developer, userID string) error {
+	stmt := `INSERT INTO developer_profile_cv_download (id, developer_profile_id, cv, user_id, downloaded_at) VALUES ($1, $2, $3, $4, NOW())`
+	id, err := ksuid.NewRandom()
+	if err != nil {
+		return err
+	}
+	_, err = r.db.Exec(stmt, id.String(), dev.ID, dev.CV, userID)
 	return err
 }
 

--- a/internal/handler/developer_cv_test.go
+++ b/internal/handler/developer_cv_test.go
@@ -1,0 +1,33 @@
+package handler
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+)
+
+func TestDecodeDeveloperCV(t *testing.T) {
+	validPDF := []byte("%PDF-1.4\n")
+	encodedPDF := "data:application/pdf;base64," + base64.StdEncoding.EncodeToString(validPDF)
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr bool
+	}{
+		{name: "empty cv is optional", input: "", wantErr: false},
+		{name: "valid pdf data url", input: encodedPDF, wantErr: false},
+		{name: "non pdf data url", input: "data:text/plain;base64," + base64.StdEncoding.EncodeToString([]byte("hello")), wantErr: true},
+		{name: "invalid base64", input: "data:application/pdf;base64,not-base64", wantErr: true},
+		{name: "too large", input: base64.StdEncoding.EncodeToString(append([]byte("%PDF"), []byte(strings.Repeat("a", maxDeveloperCVSize))...)), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := decodeDeveloperCV(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("decodeDeveloperCV() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -3,6 +3,7 @@ package handler
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -63,6 +64,35 @@ type devGetSaver interface {
 
 type tokenSaver interface {
 	SaveTokenSignOn(email, token, userType string) error
+}
+
+const maxDeveloperCVSize = 5 * 1024 * 1024
+
+func decodeDeveloperCV(encodedCV string) ([]byte, error) {
+	if encodedCV == "" {
+		return nil, nil
+	}
+	if strings.HasPrefix(encodedCV, "data:") {
+		parts := strings.SplitN(encodedCV, ",", 2)
+		if len(parts) != 2 {
+			return nil, errors.New("invalid cv data")
+		}
+		if !strings.Contains(parts[0], "application/pdf") {
+			return nil, errors.New("cv must be a pdf file")
+		}
+		encodedCV = parts[1]
+	}
+	cv, err := base64.StdEncoding.DecodeString(encodedCV)
+	if err != nil {
+		return nil, err
+	}
+	if len(cv) > maxDeveloperCVSize {
+		return nil, errors.New("cv must be 5MB or smaller")
+	}
+	if len(cv) > 0 && !bytes.HasPrefix(cv, []byte("%PDF")) {
+		return nil, errors.New("cv must be a pdf file")
+	}
+	return cv, nil
 }
 
 func GetAuthPageHandler(svr server.Server) http.HandlerFunc {
@@ -427,6 +457,7 @@ func SaveDeveloperProfileHandler(svr server.Server, devRepo devGetSaver, userRep
 			RoleLevel          string   `json:"role_level"`
 			RoleTypes          []string `json:"role_types"`
 			DetectedLocationID string   `json:"detected_location_id"`
+			CV                 string   `json:"cv,omitempty"`
 		}{}
 		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 			svr.JSON(w, http.StatusBadRequest, "request is invalid")
@@ -437,8 +468,13 @@ func SaveDeveloperProfileHandler(svr server.Server, devRepo devGetSaver, userRep
 			return
 		}
 		linkedinRe := regexp.MustCompile(`^https:\/\/(?:[a-z]{2,3}\.)?linkedin\.com\/.*$`)
-		if !linkedinRe.MatchString(req.LinkedinURL) {
+		if req.LinkedinURL != "" && !linkedinRe.MatchString(req.LinkedinURL) {
 			svr.JSON(w, http.StatusBadRequest, "linkedin url is invalid")
+			return
+		}
+		cv, err := decodeDeveloperCV(req.CV)
+		if err != nil {
+			svr.JSON(w, http.StatusBadRequest, err.Error())
 			return
 		}
 		req.Bio = bluemonday.StrictPolicy().Sanitize(req.Bio)
@@ -521,6 +557,7 @@ func SaveDeveloperProfileHandler(svr server.Server, devRepo devGetSaver, userRep
 			RoleTypes:          req.RoleTypes,
 			RoleLevel:          req.RoleLevel,
 			DetectedLocationID: detectedLocationID,
+			CV:                 cv,
 		}
 		err = userRepo.SaveTokenSignOn(strings.ToLower(req.Email), k.String(), user.UserTypeDeveloper)
 		if err != nil {
@@ -1019,61 +1056,61 @@ func TriggerWeeklyNewsletter(svr server.Server, jobRepo *job.Repository) http.Ha
 		svr.GetConfig().MachineToken,
 		func(w http.ResponseWriter, r *http.Request) {
 			go func() {
-// 				lastJobIDStr, err := jobRepo.GetValue("last_sent_job_id_weekly")
-// 				if err != nil {
-// 					svr.Log(err, "unable to retrieve last newsletter weekly job id")
-// 					return
-// 				}
-// 				lastJobID, err := strconv.Atoi(lastJobIDStr)
-// 				if err != nil {
-// 					svr.Log(err, fmt.Sprintf("unable to convert job str %s to id", lastJobIDStr))
-// 					return
-// 				}
-// 				jobPosts, err := jobRepo.GetLastNJobsFromID(svr.GetConfig().NewsletterJobsToSend, lastJobID)
-// 				if len(jobPosts) < 1 {
-// 					log.Printf("found 0 new jobs for weekly newsletter. quitting")
-// 					return
-// 				}
-// 				fmt.Printf("found %d/%d jobs for weekly newsletter\n", len(jobPosts), svr.GetConfig().NewsletterJobsToSend)
-// 				subscribers, err := database.GetEmailSubscribers(svr.Conn)
-// 				if err != nil {
-// 					svr.Log(err, fmt.Sprintf("unable to retrieve subscribers"))
-// 					return
-// 				}
-// 				var jobsHTMLArr []string
-// 				for _, j := range jobPosts {
-// 					jobsHTMLArr = append(jobsHTMLArr, `Job Title: `+j.JobTitle+`\r\nCompany: `+j.Company+`\r\nLocation: `+j.Location+`\r\nSalary: `+j.SalaryRange+`\r\nDetail: `+svr.GetConfig().URLProtocol+svr.GetConfig().SiteHost+`/job/`+j.Slug)
-// 					lastJobID = j.ID
-// 				}
-// 				jobsHTML := strings.Join(jobsHTMLArr, " ")
-// 				campaignContentHTML := `Here's a list of the newest ` + fmt.Sprintf("%d", len(jobPosts)) + ` ` + svr.GetConfig().SiteJobCategory + ` jobs this week on ` + svr.GetConfig().SiteName + `\r\n
-// ` + jobsHTML + `
-//     Check out more jobs at ` + svr.GetConfig().SiteName + `` + svr.GetConfig().URLProtocol + svr.GetConfig().SiteHost + `
-//     Get companies apply to you, join the ` + strings.ToUpper(svr.GetConfig().SiteJobCategory) + ` Developer Community ` + svr.GetConfig().SiteName + `` + svr.GetConfig().URLProtocol + svr.GetConfig().SiteHost + `/Join-` + strings.Title(svr.GetConfig().SiteJobCategory) + `-Community
-//     ` + svr.GetConfig().SiteName + `
-//     `
-// 				unsubscribeLink := `
-//     ` + svr.GetConfig().SiteName + ` | London, United Kingdom\r\nThis email was sent to %s | ` + svr.GetConfig().URLProtocol + svr.GetConfig().SiteHost + `/x/email/unsubscribe?token=%s"`
+				// 				lastJobIDStr, err := jobRepo.GetValue("last_sent_job_id_weekly")
+				// 				if err != nil {
+				// 					svr.Log(err, "unable to retrieve last newsletter weekly job id")
+				// 					return
+				// 				}
+				// 				lastJobID, err := strconv.Atoi(lastJobIDStr)
+				// 				if err != nil {
+				// 					svr.Log(err, fmt.Sprintf("unable to convert job str %s to id", lastJobIDStr))
+				// 					return
+				// 				}
+				// 				jobPosts, err := jobRepo.GetLastNJobsFromID(svr.GetConfig().NewsletterJobsToSend, lastJobID)
+				// 				if len(jobPosts) < 1 {
+				// 					log.Printf("found 0 new jobs for weekly newsletter. quitting")
+				// 					return
+				// 				}
+				// 				fmt.Printf("found %d/%d jobs for weekly newsletter\n", len(jobPosts), svr.GetConfig().NewsletterJobsToSend)
+				// 				subscribers, err := database.GetEmailSubscribers(svr.Conn)
+				// 				if err != nil {
+				// 					svr.Log(err, fmt.Sprintf("unable to retrieve subscribers"))
+				// 					return
+				// 				}
+				// 				var jobsHTMLArr []string
+				// 				for _, j := range jobPosts {
+				// 					jobsHTMLArr = append(jobsHTMLArr, `Job Title: `+j.JobTitle+`\r\nCompany: `+j.Company+`\r\nLocation: `+j.Location+`\r\nSalary: `+j.SalaryRange+`\r\nDetail: `+svr.GetConfig().URLProtocol+svr.GetConfig().SiteHost+`/job/`+j.Slug)
+				// 					lastJobID = j.ID
+				// 				}
+				// 				jobsHTML := strings.Join(jobsHTMLArr, " ")
+				// 				campaignContentHTML := `Here's a list of the newest ` + fmt.Sprintf("%d", len(jobPosts)) + ` ` + svr.GetConfig().SiteJobCategory + ` jobs this week on ` + svr.GetConfig().SiteName + `\r\n
+				// ` + jobsHTML + `
+				//     Check out more jobs at ` + svr.GetConfig().SiteName + `` + svr.GetConfig().URLProtocol + svr.GetConfig().SiteHost + `
+				//     Get companies apply to you, join the ` + strings.ToUpper(svr.GetConfig().SiteJobCategory) + ` Developer Community ` + svr.GetConfig().SiteName + `` + svr.GetConfig().URLProtocol + svr.GetConfig().SiteHost + `/Join-` + strings.Title(svr.GetConfig().SiteJobCategory) + `-Community
+				//     ` + svr.GetConfig().SiteName + `
+				//     `
+				// 				unsubscribeLink := `
+				//     ` + svr.GetConfig().SiteName + ` | London, United Kingdom\r\nThis email was sent to %s | ` + svr.GetConfig().URLProtocol + svr.GetConfig().SiteHost + `/x/email/unsubscribe?token=%s"`
 
-// 				for _, s := range subscribers {
-// 					err = svr.GetEmail().SendHTMLEmail(
-// 						email.Address{Name: svr.GetEmail().DefaultSenderName(), Email: svr.GetEmail().NoReplySenderAddress()},
-// 						email.Address{Email: s.Email},
-// 						email.Address{Name: svr.GetEmail().DefaultSenderName(), Email: svr.GetEmail().NoReplySenderAddress()},
-// 						fmt.Sprintf("Go Jobs This Week (%d New)", len(jobPosts)),
-// 						campaignContentHTML+fmt.Sprintf(unsubscribeLink, s.Email, s.Token),
-// 					)
-// 					if err != nil {
-// 						svr.Log(err, fmt.Sprintf("unable to send email for newsletter email %s", s.Email))
-// 						continue
-// 					}
-// 				}
-// 				lastJobIDStr = strconv.Itoa(lastJobID)
-// 				err = jobRepo.SetValue("last_sent_job_id_weekly", lastJobIDStr)
-// 				if err != nil {
-// 					svr.Log(err, "unable to save last weekly newsletter job id to db")
-// 					return
-// 				}
+				// 				for _, s := range subscribers {
+				// 					err = svr.GetEmail().SendHTMLEmail(
+				// 						email.Address{Name: svr.GetEmail().DefaultSenderName(), Email: svr.GetEmail().NoReplySenderAddress()},
+				// 						email.Address{Email: s.Email},
+				// 						email.Address{Name: svr.GetEmail().DefaultSenderName(), Email: svr.GetEmail().NoReplySenderAddress()},
+				// 						fmt.Sprintf("Go Jobs This Week (%d New)", len(jobPosts)),
+				// 						campaignContentHTML+fmt.Sprintf(unsubscribeLink, s.Email, s.Token),
+				// 					)
+				// 					if err != nil {
+				// 						svr.Log(err, fmt.Sprintf("unable to send email for newsletter email %s", s.Email))
+				// 						continue
+				// 					}
+				// 				}
+				// 				lastJobIDStr = strconv.Itoa(lastJobID)
+				// 				err = jobRepo.SetValue("last_sent_job_id_weekly", lastJobIDStr)
+				// 				if err != nil {
+				// 					svr.Log(err, "unable to save last weekly newsletter job id to db")
+				// 					return
+				// 				}
 			}()
 			svr.JSON(w, http.StatusOK, map[string]interface{}{"status": "ok"})
 		},
@@ -1370,6 +1407,7 @@ func UpdateDeveloperProfileHandler(svr server.Server, devRepo *developer.Reposit
 				RoleLevel          string   `json:"role_level"`
 				RoleTypes          []string `json:"role_types"`
 				DetectedLocationID string   `json:"detected_location_id"`
+				CV                 string   `json:"cv,omitempty"`
 			}{}
 			if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 				svr.Log(errors.New("invalid search status"), "invalid search status")
@@ -1382,9 +1420,14 @@ func UpdateDeveloperProfileHandler(svr server.Server, devRepo *developer.Reposit
 				return
 			}
 			linkedinRe := regexp.MustCompile(`^https:\/\/(?:[a-z]{2,3}\.)?linkedin\.com\/.*$`)
-			if !linkedinRe.MatchString(req.LinkedinURL) {
+			if req.LinkedinURL != "" && !linkedinRe.MatchString(req.LinkedinURL) {
 				svr.Log(errors.New("invalid search status"), "invalid search status")
 				svr.JSON(w, http.StatusBadRequest, "linkedin url is invalid")
+				return
+			}
+			cv, err := decodeDeveloperCV(req.CV)
+			if err != nil {
+				svr.JSON(w, http.StatusBadRequest, err.Error())
 				return
 			}
 			if _, ok := developer.ValidSearchStatus[req.SearchStatus]; !ok {
@@ -1452,6 +1495,7 @@ func UpdateDeveloperProfileHandler(svr server.Server, devRepo *developer.Reposit
 				ImageID:      req.ImageID,
 				SearchStatus: req.SearchStatus,
 				RoleLevel:    req.RoleLevel,
+				CV:           cv,
 			}
 			err = devRepo.UpdateDeveloperProfile(dev)
 			if err != nil {
@@ -3789,6 +3833,44 @@ func DownloadJobApplicationCvHandler(svr server.Server, jobRepo *job.Repository)
 			return
 		}
 	}
+}
+
+func DownloadDeveloperProfileCVHandler(svr server.Server, devRepo *developer.Repository) http.HandlerFunc {
+	return middleware.UserAuthenticatedMiddleware(
+		svr.SessionStore,
+		svr.GetJWTSigningKey(),
+		func(w http.ResponseWriter, r *http.Request) {
+			profile, err := middleware.GetUserFromJWT(r, svr.SessionStore, svr.GetJWTSigningKey())
+			if err != nil {
+				svr.Log(err, "unable to get user from JWT")
+				svr.JSON(w, http.StatusForbidden, nil)
+				return
+			}
+			if !profile.IsRecruiter && !profile.IsAdmin {
+				svr.JSON(w, http.StatusForbidden, nil)
+				return
+			}
+			vars := mux.Vars(r)
+			dev, err := devRepo.DeveloperProfileCVByID(vars["id"])
+			if err != nil {
+				svr.Log(err, "unable to find developer profile CV")
+				svr.JSON(w, http.StatusNotFound, nil)
+				return
+			}
+			if err := devRepo.TrackDeveloperProfileCVDownload(dev, profile.UserID); err != nil {
+				svr.Log(err, "unable to track developer profile CV download")
+			}
+			w.Header().Set("Content-Type", "application/pdf")
+			w.Header().Set("Content-Length", fmt.Sprintf("%d", len(dev.CV)))
+			w.Header().Set("Content-Disposition", fmt.Sprintf("inline; filename=\"%s-cv.pdf\"", slug.Make(dev.Name)))
+			_, err = w.Write(dev.CV)
+			if err != nil {
+				svr.Log(err, "unable to serve developer profile CV")
+				svr.JSON(w, http.StatusInternalServerError, nil)
+				return
+			}
+		},
+	)
 }
 
 func GetBlogPostBySlugHandler(svr server.Server, blogPostRepo *blog.Repository) http.HandlerFunc {

--- a/internal/handler/handlers.go
+++ b/internal/handler/handlers.go
@@ -2725,7 +2725,7 @@ func ApplyForJobPageHandler(svr server.Server, jobRepo *job.Repository, bookmark
 		emailAddr := r.FormValue("email")
 		jobPost, err := jobRepo.JobPostByExternalIDForEdit(externalID)
 		if err != nil {
-			svr.Log(err, fmt.Sprintf("unable to retrieve job by externalId %d, %v", externalID, err))
+			svr.Log(err, fmt.Sprintf("unable to retrieve job by externalId %s, %v", externalID, err))
 			svr.JSON(w, http.StatusBadRequest, nil)
 			return
 		}

--- a/latest-schema.sql
+++ b/latest-schema.sql
@@ -816,6 +816,7 @@ ALTER TABLE ONLY public.developer_profile ADD COLUMN role_types VARCHAR(60) NOT 
 ALTER TABLE ONLY public.developer_profile ADD COLUMN detected_location_id VARCHAR(255) DEFAULT NULL;
 ALTER TABLE ONLY public.users ADD COLUMN user_type VARCHAR(20) DEFAULT 'developer';
 ALTER TABLE ONLY public.developer_profile ADD COLUMN hourly_rate INTEGER DEFAULT 0;
+ALTER TABLE ONLY public.developer_profile ADD COLUMN cv BYTEA DEFAULT NULL;
 ALTER TABLE ONLY public.recruiter_profile DROP COLUMN company;
 ALTER TABLE ONLY public.recruiter_profile DROP COLUMN title;
 ALTER TABLE ONLY public.user_sign_on_token ADD COLUMN created_at TIMESTAMP DEFAULT NOW();
@@ -858,6 +859,15 @@ CREATE TABLE public.bookmark (
     CONSTRAINT bookmark_job_id_fkey FOREIGN KEY (job_id) REFERENCES public.job(id)
 );
 
+CREATE TABLE public.developer_profile_cv_download (
+    id CHAR(27) NOT NULL,
+    developer_profile_id CHAR(27) NOT NULL REFERENCES public.developer_profile(id),
+    cv BYTEA NOT NULL,
+    user_id bpchar(27) NOT NULL REFERENCES public.users(id),
+    downloaded_at timestamp without time zone NOT NULL,
+    CONSTRAINT developer_profile_cv_download_pkey PRIMARY KEY (id)
+);
+
 ALTER TABLE public.developer_profile_message
     ADD COLUMN sender_id bpchar(27) NOT NULL,
     ADD CONSTRAINT developer_profile_message_sender_id_fkey FOREIGN KEY (sender_id) REFERENCES public.users(id);
@@ -869,6 +879,8 @@ CREATE INDEX developer_profile_created_at_idx ON developer_profile (created_at);
 CREATE INDEX developer_profile_updated_at_idx ON developer_profile (updated_at);
 CREATE INDEX developer_profile_event_created_at_idx ON developer_profile_event(created_at);
 CREATE INDEX developer_profile_event_event_type_idx ON developer_profile_event(event_type);
+CREATE INDEX developer_profile_cv_download_profile_idx ON developer_profile_cv_download(developer_profile_id);
+CREATE INDEX developer_profile_cv_download_user_idx ON developer_profile_cv_download(user_id);
 CREATE INDEX email_subscribers_confirmed_at_idx ON email_subscribers(confirmed_at);
 CREATE INDEX job_created_at_idx ON job(created_at);
 CREATE INDEX job_approved_at_idx ON job(approved_at);

--- a/main.go
+++ b/main.go
@@ -61,15 +61,15 @@ func main() {
 	sessionStore := sessions.NewCookieStore(cfg.SessionKey)
 	robotsTxtContent, err := staticFS.ReadFile("static/robots.txt")
 	if err != nil {
-		log.Fatalf("unable to read robots.txt placeholder file: %w", err)
+		log.Fatalf("unable to read robots.txt placeholder file: %v", err)
 	}
 	securityTxtContent, err := staticFS.ReadFile("static/security.txt")
 	if err != nil {
-		log.Fatalf("unable to read security.txt placeholder file: %w", err)
+		log.Fatalf("unable to read security.txt placeholder file: %v", err)
 	}
 	adsTxtContent, err := staticFS.ReadFile("static/ads.txt")
 	if err != nil {
-		log.Fatalf("unable to read security.txt placeholder file: %w", err)
+		log.Fatalf("unable to read ads.txt placeholder file: %v", err)
 	}
 
 	devRepo := developer.NewRepository(conn)

--- a/main.go
+++ b/main.go
@@ -1,12 +1,12 @@
 package main
 
 import (
+	"embed"
 	"fmt"
 	"log"
 	"net/http"
 	_ "net/http/pprof"
 	"strings"
-	"embed"
 
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -169,6 +169,7 @@ func main() {
 	svr.RegisterRoute("/x/ddp", handler.DeleteDeveloperProfileHandler(svr, devRepo, userRepo), []string{"POST"})
 	svr.RegisterRoute("/x/smdp/{id}", handler.SendMessageDeveloperProfileHandler(svr, devRepo), []string{"POST"})
 	svr.RegisterRoute("/developer/{slug}", handler.ViewDeveloperProfileHandler(svr, devRepo, recRepo), []string{"GET"})
+	svr.RegisterRoute("/developer/{id}/cv", handler.DownloadDeveloperProfileCVHandler(svr, devRepo), []string{"GET"})
 	svr.RegisterRoute("/x/auth/message/{id}", handler.DeliverMessageDeveloperProfileHandler(svr, devRepo), []string{"GET"})
 
 	// blog

--- a/static/views/edit-developer-profile.html
+++ b/static/views/edit-developer-profile.html
@@ -171,7 +171,10 @@ footer{padding:10px;width:780px;margin:auto;}.subnav{width: 100%;text-align: lef
         <input type="text" name="full-name" id="full-name" placeholder="Full Name" style="width: 100%;" value="{{ .DeveloperProfile.Name }}"><br>
         <input type="text" name="location" id="location" placeholder="Job Location" style="width: 100%;" value="{{ .DeveloperProfile.Location }}"><br>
         <input type="number" name="hourly-rate" id="hourly-rate" placeholder="Hourly Rate in USD" style="width: 10%;" value="{{ if ne .DeveloperProfile.HourlyRate 0 }}{{ .DeveloperProfile.HourlyRate }}{{ end }}"> USD/hour<br>
-        <input type="url" name="linkedin-url" id="linkedin-url" placeholder="Linkedin URL" style="width: 100%;" value="{{ .DeveloperProfile.LinkedinURL }}"><br>
+        <input type="url" name="linkedin-url" id="linkedin-url" placeholder="Linkedin URL (optional)" style="width: 100%;" value="{{ .DeveloperProfile.LinkedinURL }}"><br>
+        <small>{{ if .DeveloperProfile.HasCV }}CV uploaded{{ else }}CV not uploaded{{ end }}</small><br>
+        <input type="file" name="cv" id="cv" accept="application/pdf" style="display: none;">
+        <label class="upload-file-label" id="cv-label" style="width:100%;border: 1px solid #595959; border-radius: 3.6px;border-style:dashed;padding: 5.4px 6.3px;display:block;" for="cv">Upload CV (PDF file only, max 5MB)</label><br>
         <div>
           <label for="profile-image" style="float: left;cursor: pointer;background: {{ .PrimaryColor }};color: #fff;padding: 6.525px 23.4px;border-radius: 3.6px;">Upload Profile Image</label>
           <div style="margin-bottom: 10px;float:left; width:100%;">
@@ -466,6 +469,51 @@ footer{padding:10px;width:780px;margin:auto;}.subnav{width: 100%;text-align: lef
               element.style.height = "5px";
               element.style.height = (element.scrollHeight)+"px";
             }
+      document.getElementById("cv").addEventListener("change", function () {
+              if (this.files && this.files[0]) {
+                      if (this.files[0].type !== "application/pdf" && this.files[0].name.split('.').pop().toLowerCase() !== "pdf") {
+                              alert("Only PDF files are allowed for CV upload");
+                              this.value = "";
+                              return;
+                            }
+                      if (this.files[0].size > 5 * 1024 * 1024) {
+                              alert("Max file size for CV is 5MB");
+                              this.value = "";
+                              return;
+                            }
+                      document.getElementById("cv-label").innerHTML = this.files[0].name.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
+                              return '&#'+i.charCodeAt(0)+';';
+                            });
+                    }
+            });
+      function readCV(cb) {
+              var cvInput = document.getElementById("cv");
+              if (!cvInput || cvInput.files.length === 0) {
+                      cb("");
+                      return;
+                    }
+              var reader = new FileReader();
+              reader.onload = function() {
+                      cb(reader.result);
+                    };
+              reader.readAsDataURL(cvInput.files[0]);
+            }
+      function buildProfilePayload(profileImageId, cv) {
+              return {
+                      id: document.getElementById('profile-id').value,
+                      fullname: document.getElementById("full-name").value,
+                      current_location: document.getElementById("location").value,
+                      bio: document.getElementById("bio").value,
+                      hourly_rate: document.getElementById("hourly-rate").value,
+                      linkedin_url: document.getElementById("linkedin-url").value,
+                      email: document.getElementById("email").value,
+                      skills: document.getElementById("tags").value,
+                      search_status: document.getElementById("search-status").value,
+                      role_level: document.getElementById("role-level").value,
+                      profile_image_id: profileImageId,
+                      cv: cv
+                    };
+            }
       function sendReq(url, isDelete) {
               var fullName = document.getElementById("full-name").value;
               var currentLocation = document.getElementById("location").value;
@@ -476,7 +524,7 @@ footer{padding:10px;width:780px;margin:auto;}.subnav{width: 100%;text-align: lef
               var tags = document.getElementById("tags").value;
               var searchStatus = document.getElementById("search-status").value;
               var roleLevel = document.getElementById("role-level").value;
-              if (empty(fullName, currentLocation, linkedinURL, bio, tags, email)) {
+              if (empty(fullName, currentLocation, bio, tags, email)) {
                       alert('Please fill all the mandatory fields');
                       return;
                     }
@@ -488,8 +536,8 @@ footer{padding:10px;width:780px;margin:auto;}.subnav{width: 100%;text-align: lef
 				alert('Skills is too long. Please use 10 skills or less');
 				return;
 			}
-              if (!isURL(linkedinURL)) {
-                      alert('"How To Apply" must be either an email address or a URL');
+              if (linkedinURL && !isURL(linkedinURL)) {
+                      alert('Linkedin URL must be a valid URL');
                       return;
                     }
               if (!isEmail(email)) {
@@ -510,29 +558,19 @@ footer{padding:10px;width:780px;margin:auto;}.subnav{width: 100%;text-align: lef
                       return;
                     }
               if (!hasFiles) {
-                      httpReq(
-                              url,
-                              {
-                                      id: document.getElementById('profile-id').value,
-                                      fullname: fullName,
-                                      current_location: currentLocation,
-                                      bio: bio,
-                                      hourly_rate: hourlyRate,
-                                      linkedin_url: linkedinURL,
-                                      email: email,
-                                      skills: tags,
-                                      search_status: searchStatus,
-                                      role_level: roleLevel,
-                                      profile_image_id: document.getElementById("profile-image-id").value
-                                    },
-                              function(bool) {
-                                      document.getElementById("spinner-0").style.display = "none";
-                                      if (bool) {
-                                              alert('Profile Updated Successfully');
-                                              window.location.reload();
-                                            } else alert('Woops there was a problem updating the profile');
-                                    }
-                            );
+                      readCV(function(cv) {
+                              httpReq(
+                                      url,
+                                      buildProfilePayload(document.getElementById("profile-image-id").value, cv),
+                                      function(bool) {
+                                              document.getElementById("spinner-0").style.display = "none";
+                                              if (bool) {
+                                                      alert('Profile Updated Successfully');
+                                                      window.location.reload();
+                                                    } else alert('Woops there was a problem updating the profile');
+                                            }
+                                    );
+                            });
                     } else {
                             // update existing image
                             var mediaFile = document.getElementById('profile-image').files[0];
@@ -553,29 +591,19 @@ footer{padding:10px;width:780px;margin:auto;}.subnav{width: 100%;text-align: lef
                                                   }
                                       var res = JSON.parse(xhr.response);
                                       profileIconId = res.id;
-                                            httpReq(
-                                                    url,
-                                                    {
-                                                            id: document.getElementById('profile-id').value,
-                                                            fullname: fullName,
-                                                            current_location: currentLocation,
-                                                            bio: bio,
-                                                            hourly_rate: hourlyRate,
-                                                            linkedin_url: linkedinURL,
-                                                            email: email,
-                                                            skills: tags,
-                                                            search_status: searchStatus,
-                                                            role_level: roleLevel,
-                                                            profile_image_id: profileIconId,
-                                                          },
-                                                    function(bool) {
-                                                            document.getElementById("spinner-0").style.display = "none";
-                                                            if (bool) {
-                                                                    alert('Profile Updated Successfully');
-                                                                    window.location.reload();
-                                                                  } else alert('Woops there was a problem updating the profile');
-                                                          }
-                                                  );
+                                            readCV(function(cv) {
+                                                    httpReq(
+                                                            url,
+                                                            buildProfilePayload(profileIconId, cv),
+                                                            function(bool) {
+                                                                    document.getElementById("spinner-0").style.display = "none";
+                                                                    if (bool) {
+                                                                            alert('Profile Updated Successfully');
+                                                                            window.location.reload();
+                                                                          } else alert('Woops there was a problem updating the profile');
+                                                                  }
+                                                        );
+                                                  });
                                           }
                                   }
                           }

--- a/static/views/submit-developer-profile.html
+++ b/static/views/submit-developer-profile.html
@@ -951,7 +951,9 @@
 			</div>
 			<input type="hidden" id="detected-location-id" name="detected-location-id">
 			<input type="number" name="hourly-rate" id="hourly-rate" placeholder="Hourly Rate" style="width: 30%;"> <div class="tooltip">USD/hour<span class="tooltiptext">Your hourly rate is only visible to recruiters who are logged-in.</span></div>
-			<input type="url" name="linkedin-url" id="linkedin-url" placeholder="LinkedIn URL" style="width: 100%;">
+			<input type="url" name="linkedin-url" id="linkedin-url" placeholder="LinkedIn URL (optional)" style="width: 100%;">
+			<input type="file" name="cv" id="cv" accept="application/pdf" style="display: none;">
+			<label class="upload-file-label" id="cv-label" style="width:100%;border: 1px solid #595959; border-radius: 3.6px;border-style:dashed;padding: 5.4px 6.3px;display:block;" for="cv">Upload CV (PDF file only, max 5MB)</label><br>
 			<select id="search-status" name="search-status" style="width:100%;">
 				<option default value="">Your Status</option>
 				<option value="actively-applying">Actively Looking</option>
@@ -1189,6 +1191,35 @@
 				});
 			}
 		});
+		document.getElementById("cv").addEventListener("change", function () {
+			if (this.files && this.files[0]) {
+				if (this.files[0].type !== "application/pdf" && this.files[0].name.split('.').pop().toLowerCase() !== "pdf") {
+					alert("Only PDF files are allowed for CV upload");
+					this.value = "";
+					return;
+				}
+				if (this.files[0].size > 5 * 1024 * 1024) {
+					alert("Max file size for CV is 5MB");
+					this.value = "";
+					return;
+				}
+				document.getElementById("cv-label").innerHTML = this.files[0].name.replace(/[\u00A0-\u9999<>\&]/gim, function(i) {
+					return '&#'+i.charCodeAt(0)+';';
+				});
+			}
+		});
+		function readCV(cb) {
+			var cvInput = document.getElementById("cv");
+			if (!cvInput || cvInput.files.length === 0) {
+				cb("");
+				return;
+			}
+			var reader = new FileReader();
+			reader.onload = function() {
+				cb(reader.result);
+			};
+			reader.readAsDataURL(cvInput.files[0]);
+		}
 		function post() {
 			var fullName = document.getElementById("full-name").value;
 			var linkedinURL = document.getElementById("linkedin-url").value;
@@ -1213,11 +1244,11 @@
 			if (document.getElementById("role-type-internship").checked) {
 				roleTypes.push('internship');
 			}
-			if (empty(tags, fullName, linkedinURL, bio, email, currentLocation, searchStatus, roleLevel, hourlyRate)) {
-				alert('You must fill all the mandatory fields (Full Name, Email, Linkedin URL, Bio, Location, Search Status, Role Level, Skills) in order to join the community');
+			if (empty(tags, fullName, bio, email, currentLocation, searchStatus, roleLevel, hourlyRate)) {
+				alert('You must fill all the mandatory fields (Full Name, Email, Bio, Location, Search Status, Role Level, Skills) in order to join the community');
 				return;
 			}
-			if (!isURL(linkedinURL) || !isLinkedinURL(linkedinURL)) {
+			if (linkedinURL && (!isURL(linkedinURL) || !isLinkedinURL(linkedinURL))) {
 				alert('Linkedin URL it\'s not a valid URL');
 				return;
 			}
@@ -1258,38 +1289,41 @@
 					}
 					var res = JSON.parse(xhr.response);
 					profileImageId = res.id;
-					var payload = {
-						fullname: fullName,
-						linkedin_url: linkedinURL,
-						bio: bio,
-						email: email,
-						tags: tags,
-						current_location: currentLocation,
-						profile_image_id: profileImageId,
-						search_status: searchStatus,
-						role_level: roleLevel,
-						role_types: roleTypes,
-						hourly_rate: hourlyRate,
-						detected_location_id: detectedLocationId,
-					};
-					http(
-						'/x/sdp',
-						payload,
-						function (success, body, statusCode) {
-							if (success) {
-								document.getElementById("spinner-0").style.display = "none";
-								alert('Please check your email to confirm your profile.');
-								window.location.href = '/Submit-Developer-Profile';
-							} else {
-								document.getElementById("spinner-0").style.display = "none";
-								if (statusCode == 400) {
-									alert('There was a problem with your request. ' + body);
+					readCV(function(cv) {
+						var payload = {
+							fullname: fullName,
+							linkedin_url: linkedinURL,
+							bio: bio,
+							email: email,
+							tags: tags,
+							current_location: currentLocation,
+							profile_image_id: profileImageId,
+							search_status: searchStatus,
+							role_level: roleLevel,
+							role_types: roleTypes,
+							hourly_rate: hourlyRate,
+							detected_location_id: detectedLocationId,
+							cv: cv,
+						};
+						http(
+							'/x/sdp',
+							payload,
+							function (success, body, statusCode) {
+								if (success) {
+									document.getElementById("spinner-0").style.display = "none";
+									alert('Please check your email to confirm your profile.');
+									window.location.href = '/Submit-Developer-Profile';
 								} else {
-									alert('There was a problem with your request, please try again later.');
+									document.getElementById("spinner-0").style.display = "none";
+									if (statusCode == 400) {
+										alert('There was a problem with your request. ' + body);
+									} else {
+										alert('There was a problem with your request, please try again later.');
+									}
 								}
 							}
-						}
-					);
+						);
+					});
 				}
 			}
 		}

--- a/static/views/view-developer-profile.html
+++ b/static/views/view-developer-profile.html
@@ -295,9 +295,7 @@ background-color: #FF6600
     <small>{{ if or .IsUserRecruiter .IsUserAdmin }}{{ if ne .DeveloperProfile.HourlyRate 0 }}Hourly Rate: <b>{{ .DeveloperProfile.HourlyRate }} USD/hour</b>{{ else }}Hourly Rate: <b>Not specified</b>{{ end }}{{ end }}</small><br>
     <small>Experience Level: <b>{{ stringTitle .DeveloperProfile.RoleLevel }}</b></small><br>
     <small>Work Preference: <b>{{ .DeveloperProfile.RoleTypeAsString }}</b></small><br>
-    {{ if and .DeveloperProfile.LinkedinURL (or .IsUserRecruiter .IsUserAdmin) }}<small>LinkedIn: <a href="{{ .DeveloperProfile.LinkedinURL }}" target="_blank" rel="nofollow">{{ .DeveloperProfile.LinkedinURL }}</a></small><br>{{ end }}
-    {{ if and .DeveloperProfile.TwitterURL (or .IsUserRecruiter .IsUserAdmin) }}<small>Twitter: <a href="{{ .DeveloperProfile.TwitterURL }}" target="_blank" rel="nofollow">{{ .DeveloperProfile.TwitterURL }}</a></small><br>{{ end }}
-    {{ if and .DeveloperProfile.GithubURL (or .IsUserRecruiter .IsUserAdmin) }}<small>GitHub: <a href="{{ .DeveloperProfile.GithubURL }}" target="_blank" rel="nofollow">{{ .DeveloperProfile.GithubURL }}</a></small><br>{{ end }}
+    {{ if or .IsUserRecruiter .IsUserAdmin }}<small>CV: {{ if .DeveloperProfile.HasCV }}<a href="/developer/{{ .DeveloperProfile.ID }}/cv" target="_blank" rel="nofollow">View CV</a>{{ else }}CV not uploaded{{ end }}</small><br>{{ end }}
 		<small>Last Updated <b>{{ .DeveloperProfile.UpdatedAtHumanized }}</b></small><br>
 		<p id="skills-{{ .DeveloperProfile.ID }}">
 		  {{ range $x, $y := .DeveloperProfile.SkillsArray }}


### PR DESCRIPTION
Fixes #74

/claim #74

This adds optional CV support for developer profiles:

- stores an optional PDF CV on `developer_profile` as `BYTEA`
- adds `developer_profile_cv_download` records with id, developer profile id, CV bytes, user id, and download timestamp
- allows CV upload during developer signup and profile edit
- makes LinkedIn optional in frontend and backend validation
- replaces recruiter/admin-visible social profile links on developer pages with CV availability/download status
- adds recruiter/admin-only CV download at `/developer/{id}/cv`
- validates CV uploads as PDF data, max 5MB
- adds unit coverage for CV decoding/validation

Validation:

- `go test -vet=off ./...` passes
- `go test ./...` is blocked by pre-existing vet findings outside this change:
  - `internal/handler/handlers.go:2728` has an existing `%d`/string mismatch
  - `main.go:64`, `main.go:68`, `main.go:72` use `%w` with `log.Fatalf`